### PR TITLE
修复横排模式候选项宽度问题

### DIFF
--- a/CandidateWindow.cpp
+++ b/CandidateWindow.cpp
@@ -264,7 +264,10 @@ void CandidateWindow::onPaint(WPARAM wp, LPARAM lp) {
 			y += itemHeight_ + rowSpacing_;
 		}
 		else {
-			x += colSpacing_ + selKeyWidth_ + textWidth_;
+            SIZE candidateSize;
+            wstring& item = items_.at(i);
+            ::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);
+			x += colSpacing_ + selKeyWidth_ + candidateSize.cx;
 		}
 	}
 	SelectObject(hDC, oldFont);
@@ -299,8 +302,12 @@ void CandidateWindow::recalculateSize() {
 		SIZE candidateSize;
 		wstring& item = items_.at(i);
 		::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);
-		if(candidateSize.cx > textWidth_)
-			textWidth_ = candidateSize.cx;
+        if (items_.size() > candPerRow_ && candidateSize.cx > textWidth_) {
+            textWidth_ = candidateSize.cx;
+        }
+        else {
+            width += selKeyWidth_ + candidateSize.cx;
+        }
 		int itemHeight = max(candidateSize.cy, selKeySize.cy);
 		if(itemHeight > itemHeight_)
 			itemHeight_ = itemHeight;
@@ -309,7 +316,6 @@ void CandidateWindow::recalculateSize() {
 	::ReleaseDC(hwnd(), hDC);
 
 	if(items_.size() <= candPerRow_) {
-		width = items_.size() * (selKeyWidth_ + textWidth_);
 		width += colSpacing_ * (items_.size() - 1);
 		width += margin_ * 2;
 		height = itemHeight_ + margin_ * 2;
@@ -421,7 +427,17 @@ void CandidateWindow::paintItem(HDC hDC, int i,  int x, int y) {
 	// paint the candidate string
 	wstring& item = items_.at(i);
 	textRect.left += selKeyWidth_;
-	textRect.right = textRect.left + textWidth_;
+
+    if (items_.size() <= candPerRow_) {
+        SIZE candidateSize;
+        wstring& item = items_.at(i);
+        ::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);
+        textRect.right = textRect.left + candidateSize.cx;
+    }
+    else {
+        textRect.right = textRect.left + textWidth_;
+    }
+
 
 	if(useCursor_ && i == currentSel_) { // invert the selected item
 		::SetTextColor(hDC, hilitedCandidateTextColor_);

--- a/CandidateWindow.cpp
+++ b/CandidateWindow.cpp
@@ -255,6 +255,7 @@ void CandidateWindow::onPaint(WPARAM wp, LPARAM lp) {
 	// paint items
 	int col = 0;
 	int x = margin_, y = margin_;
+    bool horizontal = isHorizontal();
 	for(int i = 0, n = items_.size(); i < n; ++i) {
 		paintItem(hDC, i, x, y);
 		++col; // go to next column
@@ -264,10 +265,16 @@ void CandidateWindow::onPaint(WPARAM wp, LPARAM lp) {
 			y += itemHeight_ + rowSpacing_;
 		}
 		else {
-            SIZE candidateSize;
-            wstring& item = items_.at(i);
-            ::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);
-			x += colSpacing_ + selKeyWidth_ + candidateSize.cx;
+            x += colSpacing_ + selKeyWidth_;
+            if (horizontal) {
+                SIZE candidateSize;
+                wstring& item = items_.at(i);
+                ::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);
+                x += candidateSize.cx;
+            }
+            else {
+                x += textWidth_;
+            }
 		}
 	}
 	SelectObject(hDC, oldFont);
@@ -302,7 +309,7 @@ void CandidateWindow::recalculateSize() {
 		SIZE candidateSize;
 		wstring& item = items_.at(i);
 		::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);
-        if (items_.size() > candPerRow_ && candidateSize.cx > textWidth_) {
+        if (!isHorizontal() && candidateSize.cx > textWidth_) {
             textWidth_ = candidateSize.cx;
         }
         else {
@@ -315,7 +322,7 @@ void CandidateWindow::recalculateSize() {
 	::SelectObject(hDC, oldFont);
 	::ReleaseDC(hwnd(), hDC);
 
-	if(items_.size() <= candPerRow_) {
+	if(isHorizontal()) {
 		width += colSpacing_ * (items_.size() - 1);
 		width += margin_ * 2;
 		height = itemHeight_ + margin_ * 2;
@@ -428,7 +435,7 @@ void CandidateWindow::paintItem(HDC hDC, int i,  int x, int y) {
 	wstring& item = items_.at(i);
 	textRect.left += selKeyWidth_;
 
-    if (items_.size() <= candPerRow_) {
+    if (isHorizontal()) {
         SIZE candidateSize;
         wstring& item = items_.at(i);
         ::GetTextExtentPoint32W(hDC, item.c_str(), item.length(), &candidateSize);

--- a/CandidateWindow.h
+++ b/CandidateWindow.h
@@ -155,6 +155,8 @@ protected: // COM object should not be deleted directly. calling Release() inste
 	~CandidateWindow(void);
 
 private:
+
+    inline bool isHorizontal() const { return items_.size() <= candPerRow_; }
 	ULONG refCount_;
 	BOOL shown_;
 

--- a/CandidateWindow.h
+++ b/CandidateWindow.h
@@ -63,9 +63,9 @@ public:
 		return items_;
 	}
 
-	void setItems(const std::vector<std::wstring>& items, const std::vector<wchar_t>& sekKeys) {
+	void setItems(const std::vector<std::wstring>& items, const std::vector<wchar_t>& selKeys) {
 		items_ = items;
-		selKeys_ = selKeys_;
+		selKeys_ = selKeys;
 		recalculateSize();
 		refresh();
 	}


### PR DESCRIPTION
fix https://github.com/osfans/PRIME/issues/12 , https://github.com/EasyIME/PIME/issues/299

横排模式（实际候选词数小于等于每排允许的候选数）下选词条的宽度应和文本实际占用的宽度相等。